### PR TITLE
guard against _zipkin_span not set in g

### DIFF
--- a/flask_zipkin.py
+++ b/flask_zipkin.py
@@ -123,6 +123,6 @@ class Zipkin(object):
         return zipkin.create_http_headers_for_new_span()
 
     def logging(self, **kwargs):
-        if g._zipkin_span and g._zipkin_span.logging_context:
+        if hasattr(g, '_zipkin_span') and g._zipkin_span and g._zipkin_span.logging_context:
             g._zipkin_span.logging_context.binary_annotations_dict.update(
                 kwargs)


### PR DESCRIPTION
It is possible that `zipkin.logging` is called before request actually has been made -- in unit tests, for example (`with app.test_request_context()` does not run before/after request hooks).