### PR TITLE
Add child span decorator

### DIFF
--- a/flask_zipkin.py
+++ b/flask_zipkin.py
@@ -145,6 +145,11 @@ def child_span(f):
         )
         kwargs['span'] = span
         with span:
-            return f(*args, **kwargs)
+            val = f(*args, **kwargs)
+            span.update_binary_annotations({
+                'function_args': args,
+                'function_returns': val,
+            })
+            return val
 
     return decorated

--- a/flask_zipkin.py
+++ b/flask_zipkin.py
@@ -1,12 +1,13 @@
 import logging
 import random
 import string
-from flask import g
-from flask import request
+
+import flask
+import requests
 from flask import _app_ctx_stack
 from flask import current_app
-
-import requests
+from flask import g
+from flask import request
 from py_zipkin import zipkin
 
 
@@ -134,3 +135,16 @@ class Zipkin(object):
                 g._zipkin_span.logging_context]):
             g._zipkin_span.logging_context.binary_annotations_dict.update(
                 kwargs)
+
+
+def child_span(f):
+    def decorated(*args, **kwargs):
+        span = zipkin.zipkin_span(
+            service_name=flask.current_app.name,
+            span_name=f.__name__,
+        )
+        kwargs['span'] = span
+        with span:
+            return f(*args, **kwargs)
+
+    return decorated


### PR DESCRIPTION
This decorator aims to make easier people creating child span. Normally we have to create a span resource everytime we want to create a child span. For example:

```python
def some_method():
    with zipkin_span(service_name='example', span_name='some_method') as z:
        result = do_something()
        z.update_binary_annotations({'result': result})
```

Using this decorator we can do this instead:

```python
@flask_zipkin.child_span
def some_method(*args, **kwargs):
    result = do_something()
    kwargs['span'].update_binary_annotations({'result': result})  
```

The decorated method will use flask application name as `service_name` and the decorated method name as `span_name`.