### PR TITLE
Add method name to span name

### DIFF
--- a/flask_zipkin.py
+++ b/flask_zipkin.py
@@ -96,7 +96,7 @@ class Zipkin(object):
 
         span = zipkin.zipkin_span(
             service_name=self.app.name,
-            span_name=request.endpoint,
+            span_name='{0}.{1}'.format(request.endpoint, request.mehod),
             transport_handler=handler,
             sample_rate=self._sample_rate,
             zipkin_attrs=zipkin_attrs


### PR DESCRIPTION
Span name format changed. Now it consists from endpoint and method names: _endpoint.method_.