### PR TITLE
Doesn't work without ZIPKIN_DSN

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,8 @@ from flask_zipkin import Zipkin
 
 zipkin = Zipkin(sample_rate=10)
 zipkin.init_app(app)
+
+app.config['ZIPKIN_DSN'] = "http://127.0.0.1:9411/api/v1/spans"
 ```
 
 ## Advance Usage

--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ you can simply use it as other flask extensions.
 ```python
 from flask_zipkin import Zipkin
 
-zipkin = Zipkin(sample_rate=10)
-zipkin.init_app(app)
-
+zipkin = Zipkin(app, sample_rate=10)
 app.config['ZIPKIN_DSN'] = "http://127.0.0.1:9411/api/v1/spans"
 ```
 


### PR DESCRIPTION
ZIPKIN_DSN should be set for the basic usage, because there is no default.