### PR TITLE
fix span data is old

### DIFF
--- a/flask_zipkin.py
+++ b/flask_zipkin.py
@@ -73,8 +73,6 @@ class Zipkin(object):
         return (view_func not in self._exempt_views)
 
     def _safe_headers(self, headers):
-        if hasattr(self, "_headers"):
-            return self._headers
         self._headers = dict((k.lower(), v) for k, v in headers.__iter__())
         return self._headers
 


### PR DESCRIPTION
I have two applications, one named a and the other named B. their request order is that the client requests application a, and application a requests application B again. The data sent by application B for the first time is OK, but the data sent later is old data